### PR TITLE
全オープンIssue #105〜#111を解消

### DIFF
--- a/apps/app/android/app/src/main/AndroidManifest.xml
+++ b/apps/app/android/app/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:allowBackup="false"
+        android:enableOnBackInvokedCallback="true"
         android:requestLegacyExternalStorage="true"
         android:usesCleartextTraffic="true"
         android:fullBackupContent="false">

--- a/apps/app/lib/app/pages/group/groups_page.dart
+++ b/apps/app/lib/app/pages/group/groups_page.dart
@@ -191,7 +191,7 @@ class _ListTile extends HookConsumerWidget with PresentationMixin {
       ) => ErrorView(error, stackTrace),
 
       // TODO(yakitama5): 読み込み中表示を後から作ること
-      _ => const CircularProgressIndicator(),
+      _ => const ExpressiveLoadingIndicator(),
     };
   }
 

--- a/apps/app/lib/app/pages/group/share_link_page.dart
+++ b/apps/app/lib/app/pages/group/share_link_page.dart
@@ -22,7 +22,7 @@ class ShareLinkPage extends HookConsumerWidget with PresentationMixin {
 
     // 画面としてはずっとぐるぐる回るだけ
     return const Scaffold(
-      body: Center(child: CircularProgressIndicator.adaptive()),
+      body: Center(child: ExpressiveLoadingIndicator()),
     );
   }
 

--- a/apps/app/lib/app/pages/item/components/item_detail_pager.dart
+++ b/apps/app/lib/app/pages/item/components/item_detail_pager.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:packages_domain/item.dart';
+
+typedef ItemDetailBuilder = Widget Function(BuildContext context, Item item);
+
+/// 横スワイプで検索結果内の前後の欲しいものを表示する。
+class ItemDetailPager extends HookWidget {
+  const ItemDetailPager({
+    super.key,
+    required this.items,
+    required this.initialItemId,
+    required this.itemBuilder,
+  });
+
+  final List<Item> items;
+  final ItemId initialItemId;
+  final ItemDetailBuilder itemBuilder;
+
+  @override
+  Widget build(BuildContext context) {
+    final itemIndex = items.indexWhere((item) => item.id == initialItemId);
+    final initialPage = itemIndex < 0 ? 0 : itemIndex;
+    final controller = usePageController(initialPage: initialPage);
+
+    return PageView.builder(
+      controller: controller,
+      itemCount: items.length,
+      itemBuilder: (context, index) => itemBuilder(context, items[index]),
+    );
+  }
+}

--- a/apps/app/lib/app/pages/item/components/items_list_tile.dart
+++ b/apps/app/lib/app/pages/item/components/items_list_tile.dart
@@ -72,7 +72,7 @@ class ItemsListTile extends StatelessWidget with PresentationMixin {
       title: messages.title,
       message: messages.message(name: item.name),
     );
-    if (result != OkCancelResult.ok) {
+    if (result != OkCancelResult.ok || !context.mounted) {
       return;
     }
 

--- a/apps/app/lib/app/pages/item/components/items_list_tile.dart
+++ b/apps/app/lib/app/pages/item/components/items_list_tile.dart
@@ -1,36 +1,84 @@
+import 'package:adaptive_dialog/adaptive_dialog.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_app/app/pages/item/components/items_empty_image.dart';
 import 'package:flutter_app/i18n/strings.g.dart';
+import 'package:flutter_slidable/flutter_slidable.dart';
+import 'package:packages_designsystem/i18n.dart';
 import 'package:packages_designsystem/widgets.dart';
 import 'package:packages_domain/item.dart';
 
-class ItemsListTile extends StatelessWidget {
-  const ItemsListTile({super.key, required this.item, this.onTap});
+class ItemsListTile extends StatelessWidget with PresentationMixin {
+  const ItemsListTile({
+    super.key,
+    required this.item,
+    this.onTap,
+    this.onDelete,
+  });
 
   final Item item;
   final VoidCallback? onTap;
+  final Future<void> Function()? onDelete;
 
   @override
   Widget build(BuildContext context) {
     // 画像は先頭1件を利用する
     final imageUrl = item.primaryImageUrl;
 
-    return ListTile(
-      onTap: onTap,
-      title: Text(item.name),
-      leading: ClipRRect(
-        borderRadius: BorderRadius.circular(12),
-        child: (imageUrl == null)
-            ? const ItemsEmptyImage(width: 96, height: double.infinity)
-            : NetworkImageWithPlaceholder(
-                imageUrl: imageUrl,
-                width: 96,
-                fit: BoxFit.cover,
-              ),
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Slidable(
+      endActionPane: ActionPane(
+        motion: const DrawerMotion(),
+        extentRatio: 0.25,
+        children: [
+          SlidableAction(
+            onPressed: (_) => _confirmAndDelete(context),
+            backgroundColor: colorScheme.error,
+            foregroundColor: colorScheme.onError,
+            icon: Icons.delete,
+            label: commonI18n.common.delete,
+          ),
+        ],
       ),
-      subtitle: Text(
-        i18n.item.common.currencyFormat(price: item.purchase?.price ?? 0),
+      child: ListTile(
+        onTap: onTap,
+        title: Text(item.name),
+        leading: ClipRRect(
+          borderRadius: BorderRadius.circular(12),
+          child: (imageUrl == null)
+              ? const ItemsEmptyImage(width: 96, height: double.infinity)
+              : NetworkImageWithPlaceholder(
+                  imageUrl: imageUrl,
+                  width: 96,
+                  fit: BoxFit.cover,
+                ),
+        ),
+        subtitle: Text(
+          i18n.item.common.currencyFormat(price: item.purchase?.price ?? 0),
+        ),
       ),
+    );
+  }
+
+  Future<void> _confirmAndDelete(BuildContext context) async {
+    final delete = onDelete;
+    if (delete == null) {
+      return;
+    }
+
+    final messages = commonI18n.common.deleteConfirmDialog;
+    final result = await showOkCancelAlertDialog(
+      context: context,
+      title: messages.title,
+      message: messages.message(name: item.name),
+    );
+    if (result != OkCancelResult.ok) {
+      return;
+    }
+
+    await execute(
+      action: delete,
+      successMessage: commonI18n.common.deletionComplete,
     );
   }
 }

--- a/apps/app/lib/app/pages/item/components/items_view.dart
+++ b/apps/app/lib/app/pages/item/components/items_view.dart
@@ -54,6 +54,8 @@ class ItemsView extends HookConsumerWidget {
                   key: ValueKey(item),
                   item: item,
                   onTap: () => onSelect(context, ref, item.id),
+                  onDelete: () =>
+                      ref.read(itemUsecaseProvider).delete(itemId: item.id),
                 ),
               };
             },

--- a/apps/app/lib/app/pages/item/item_page.dart
+++ b/apps/app/lib/app/pages/item/item_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_app/app/pages/item/components/item_detail_pager.dart';
 import 'package:flutter_app/app/pages/item/components/item_images.dart';
 import 'package:flutter_app/app/pages/item/components/item_transfer_group_bottom_sheet.dart';
 import 'package:flutter_app/app/pages/item/components/rating_icon.dart';
@@ -27,6 +28,7 @@ class ItemPage extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final user = ref.watch(authUserProvider);
     final item = ref.watch(ItemDetailProviders.itemProvider);
+    final searchItems = ref.watch(searchAllItemsProvider);
 
     // 欲しい物と購入情報に応じて判定を行う
     return switch ((item, user)) {
@@ -41,7 +43,11 @@ class ItemPage extends HookConsumerWidget {
         AsyncData(value: final Item itemData),
         AsyncData(value: final User userData),
       ) =>
-        _ItemDetailView(item: itemData, user: userData),
+        _SwipeableItemDetailView(
+          initialItem: itemData,
+          user: userData,
+          searchItems: searchItems.value,
+        ),
 
       // どちらかがエラーの場合はエラー
       (AsyncError(error: final error, stackTrace: final stackTrace), _) ||
@@ -53,6 +59,32 @@ class ItemPage extends HookConsumerWidget {
       // 一瞬なのでローディング中は何も表示しない
       _ => const SizedBox.shrink(),
     };
+  }
+}
+
+class _SwipeableItemDetailView extends StatelessWidget {
+  const _SwipeableItemDetailView({
+    required this.initialItem,
+    required this.user,
+    required this.searchItems,
+  });
+
+  final Item initialItem;
+  final User user;
+  final List<Item>? searchItems;
+
+  @override
+  Widget build(BuildContext context) {
+    final items = searchItems;
+    if (items == null || !items.any((item) => item.id == initialItem.id)) {
+      return _ItemDetailView(item: initialItem, user: user);
+    }
+
+    return ItemDetailPager(
+      items: items,
+      initialItemId: initialItem.id,
+      itemBuilder: (_, item) => _ItemDetailView(item: item, user: user),
+    );
   }
 }
 

--- a/apps/app/lib/app/pages/item/items_page.dart
+++ b/apps/app/lib/app/pages/item/items_page.dart
@@ -21,7 +21,7 @@ class ItemsPage extends HookConsumerWidget {
     final scrollController = useScrollController();
 
     return Scaffold(
-      body: RefreshIndicator(
+      body: ExpressiveRefreshIndicator(
         onRefresh: () => ref.read(itemUsecaseProvider).refreshSearchItems(),
         child: CustomScrollView(
           slivers: [

--- a/apps/app/lib/app/pages/settings/account_page.dart
+++ b/apps/app/lib/app/pages/settings/account_page.dart
@@ -60,7 +60,7 @@ class AccountPage extends HookConsumerWidget with PresentationMixin {
         ),
       ),
       error: ErrorView.new,
-      loading: CircularProgressIndicator.new,
+      loading: ExpressiveLoadingIndicator.new,
     );
   }
 

--- a/apps/app/lib/app/pages/user/profile_page.dart
+++ b/apps/app/lib/app/pages/user/profile_page.dart
@@ -21,13 +21,13 @@ class ProfilePage extends HookConsumerWidget {
       skipLoadingOnRefresh: true,
       skipLoadingOnReload: true,
       data: (data) => data == null
-          ? const CircularProgressIndicator()
+          ? const ExpressiveLoadingIndicator()
           : UserFormModelFormBuilder(
               model: UserFormModel(name: data.name, ageGroup: data.ageGroup),
               builder: (context, formModel, child) => const _Form(),
             ),
       error: ErrorView.new,
-      loading: CircularProgressIndicator.new,
+      loading: ExpressiveLoadingIndicator.new,
     );
   }
 }

--- a/apps/app/lib/app/routes/src/background_notification_click_listener.dart
+++ b/apps/app/lib/app/routes/src/background_notification_click_listener.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_app/app/routes/src/providers/go_router_provider.dart';
+import 'package:flutter_app/app/routes/src/notification_navigation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:nested/nested.dart';
 import 'package:packages_application/common.dart';
@@ -33,13 +33,11 @@ class BackgroundNotificationClickListener extends SingleChildStatelessWidget {
     WidgetRef ref,
     NotificationMessage? message,
   ) async {
-    final path = message?.path;
     logger.d('Background Click');
-    if (path == null) {
+    if (message == null) {
       return;
     }
 
-    // GoRouterの定義よりも上位階層のため、Providerから遷移先を指定する
-    ref.read(goRouterProvider).go(path);
+    await navigateFromNotification(ref, message);
   }
 }

--- a/apps/app/lib/app/routes/src/foreground_notification_click_listener.dart
+++ b/apps/app/lib/app/routes/src/foreground_notification_click_listener.dart
@@ -1,5 +1,7 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
-import 'package:flutter_app/app/routes/src/providers/go_router_provider.dart';
+import 'package:flutter_app/app/routes/src/notification_navigation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:nested/nested.dart';
 import 'package:packages_core/util.dart';
@@ -18,14 +20,7 @@ class ForegroundNotificationClickListener extends SingleChildStatelessWidget {
           onNotificationClick: (message) {
             logger.d('Foreground Click');
 
-            final path = message.path;
-
-            if (path == null) {
-              return;
-            }
-
-            // GoRouterの定義よりも上位階層のため、Providerから遷移先を指定する
-            ref.read(goRouterProvider).go(path);
+            unawaited(navigateFromNotification(ref, message));
           },
         );
       },

--- a/apps/app/lib/app/routes/src/notification_navigation.dart
+++ b/apps/app/lib/app/routes/src/notification_navigation.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_app/app/routes/src/providers/go_router_provider.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:packages_application/group.dart';
+import 'package:packages_domain/group.dart';
+import 'package:packages_domain/notification.dart';
+
+typedef SelectNotificationGroup = Future<void> Function(GroupId groupId);
+typedef OpenNotificationPath = void Function(String path);
+
+/// 通知が発生したグループを選択してから、通知先を開く。
+Future<void> openNotification({
+  required NotificationMessage message,
+  required SelectNotificationGroup selectGroup,
+  required OpenNotificationPath openPath,
+}) async {
+  final path = message.path;
+  if (path == null || path.isEmpty) {
+    return;
+  }
+
+  final groupId = message.groupId;
+  if (groupId != null) {
+    await selectGroup(groupId);
+  }
+
+  openPath(path);
+}
+
+Future<void> navigateFromNotification(
+  WidgetRef ref,
+  NotificationMessage message,
+) => openNotification(
+  message: message,
+  selectGroup: (groupId) =>
+      ref.read(currentGroupIdProvider.notifier).set(groupId: groupId),
+  openPath: ref.read(goRouterProvider).go,
+);

--- a/apps/app/lib/app/routes/src/providers/router_notifier_provider.dart
+++ b/apps/app/lib/app/routes/src/providers/router_notifier_provider.dart
@@ -19,13 +19,12 @@ class RouterNotifier extends _$RouterNotifier implements Listenable {
 
   @override
   Future<void> build() async {
-    listenSelf((previous, next) {
-      if (state.isLoading) {
-        return;
-      }
-
-      routerListener?.call();
-    });
+    // GoRouter に認証状態の変化を通知し、redirect を再評価する。
+    // RouterNotifier 自身の state は認証状態に依存しないため、listenSelf では
+    // サインイン/サインアウトを検知できない。
+    ref
+      ..listen(authStatusProvider, (_, _) => routerListener?.call())
+      ..listen(authUserProvider, (_, _) => routerListener?.call());
   }
 
   Future<String?> redirect(

--- a/apps/app/lib/app/routes/src/providers/router_notifier_provider.g.dart
+++ b/apps/app/lib/app/routes/src/providers/router_notifier_provider.g.dart
@@ -35,7 +35,7 @@ final class RouterNotifierProvider
   RouterNotifier create() => RouterNotifier();
 }
 
-String _$routerNotifierHash() => r'643d139fb72fac8a8444d86749e33cc323343cab';
+String _$routerNotifierHash() => r'3114b2b3aa441224684f62d8e857fb9c339cafa6';
 
 abstract class _$RouterNotifier extends $AsyncNotifier<void> {
   FutureOr<void> build();

--- a/apps/app/lib/app/routes/src/routes_data.dart
+++ b/apps/app/lib/app/routes/src/routes_data.dart
@@ -24,6 +24,7 @@ import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:packages_application/group.dart';
 import 'package:packages_application/item.dart';
+import 'package:packages_designsystem/widgets.dart';
 import 'package:packages_domain/group.dart';
 import 'package:packages_domain/item.dart';
 
@@ -69,7 +70,7 @@ class RootRouteData extends GoRouteData with $RootRouteData {
   @override
   Widget build(BuildContext context, GoRouterState state) =>
       // ぐるぐる回すだけ
-      const Scaffold(body: Center(child: CircularProgressIndicator.adaptive()));
+      const Scaffold(body: Center(child: ExpressiveLoadingIndicator()));
 }
 
 final GlobalKey<NavigatorState> _shellNavigatorKey =

--- a/apps/app/lib/main.dart
+++ b/apps/app/lib/main.dart
@@ -19,9 +19,10 @@ Future<void> main() async {
       // 自動リトライは無効化
       retry: (_, _) => null,
       overrides: [
-        // 初期ロケーションの設定
-        initialLocationProvider.overrideWithValue(
-          initializedResult.initialMessage?.path,
+        // 通知から起動した場合も、認証とグループ選択後に遷移する
+        initialLocationProvider.overrideWithValue(null),
+        initialNotificationMessageProvider.overrideWith(
+          (ref) => initializedResult.initialMessage,
         ),
 
         // 起動時に取得したアプリの基本情報を設定

--- a/apps/app/test/app/pages/item/components/item_detail_pager_test.dart
+++ b/apps/app/test/app/pages/item/components/item_detail_pager_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_app/app/pages/item/components/item_detail_pager.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:packages_domain/item.dart';
+
+void main() {
+  testWidgets('moves to adjacent item with a horizontal swipe', (tester) async {
+    final items = [_item('first'), _item('second'), _item('third')];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ItemDetailPager(
+          items: items,
+          initialItemId: items[1].id,
+          itemBuilder: (_, item) => Scaffold(body: Text(item.name)),
+        ),
+      ),
+    );
+
+    expect(find.text('second'), findsOneWidget);
+
+    await tester.drag(find.byType(PageView), const Offset(-400, 0));
+    await tester.pumpAndSettle();
+
+    expect(find.text('third'), findsOneWidget);
+  });
+}
+
+Item _item(String id) => Item(
+  id: ItemId(id),
+  name: id,
+  wishRank: 1,
+  purchaseStatus: PurchaseStatus.notPurchased,
+  createdAt: DateTime(2026),
+  updatedAt: DateTime(2026),
+);

--- a/apps/app/test/app/pages/item/components/items_list_tile_test.dart
+++ b/apps/app/test/app/pages/item/components/items_list_tile_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_app/app/pages/item/components/items_list_tile.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:packages_designsystem/i18n.dart';
+import 'package:packages_domain/item.dart';
+
+void main() {
+  testWidgets('deletes an item from the slide action after confirmation', (
+    tester,
+  ) async {
+    var deleted = false;
+    final item = Item(
+      id: ItemId('item'),
+      name: 'slide target',
+      wishRank: 1,
+      purchaseStatus: PurchaseStatus.notPurchased,
+      createdAt: DateTime(2026),
+      updatedAt: DateTime(2026),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ItemsListTile(
+            item: item,
+            onDelete: () async => deleted = true,
+          ),
+        ),
+      ),
+    );
+
+    await tester.drag(find.text(item.name), const Offset(-400, 0));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(commonI18n.common.delete));
+    await tester.pumpAndSettle();
+
+    expect(find.text(commonI18n.common.deleteConfirmDialog.title), findsOne);
+
+    await tester.tap(find.text('OK'));
+    await tester.pumpAndSettle();
+
+    expect(deleted, isTrue);
+  });
+}

--- a/apps/app/test/app/routes/notification_navigation_test.dart
+++ b/apps/app/test/app/routes/notification_navigation_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_app/app/routes/src/notification_navigation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:packages_domain/group.dart';
+import 'package:packages_domain/notification.dart';
+
+void main() {
+  test('selects the notification group before opening its path', () async {
+    final events = <String>[];
+
+    await openNotification(
+      message: NotificationMessage(
+        groupId: GroupId('target-group'),
+        path: '/items/item/target-item',
+      ),
+      selectGroup: (groupId) async => events.add('group:${groupId.value}'),
+      openPath: (path) => events.add('path:$path'),
+    );
+
+    expect(events, [
+      'group:target-group',
+      'path:/items/item/target-item',
+    ]);
+  });
+
+  test('does not navigate when notification path is absent', () async {
+    var navigated = false;
+
+    await openNotification(
+      message: const NotificationMessage(path: null),
+      selectGroup: (_) async {},
+      openPath: (_) => navigated = true,
+    );
+
+    expect(navigated, isFalse);
+  });
+}

--- a/apps/app/test/app/routes/providers/router_notifier_provider_test.dart
+++ b/apps/app/test/app/routes/providers/router_notifier_provider_test.dart
@@ -1,0 +1,41 @@
+import 'dart:async';
+
+import 'package:flutter_app/app/routes/src/providers/router_notifier_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:packages_application/user.dart';
+import 'package:packages_domain/user.dart';
+
+void main() {
+  test('notifies GoRouter when authentication status changes', () async {
+    final authStatus = StreamController<AuthStatus?>();
+    addTearDown(authStatus.close);
+    final container = ProviderContainer(
+      overrides: [
+        authStatusProvider.overrideWith((ref) => authStatus.stream),
+        authUserProvider.overrideWith((ref) => null),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final subscription = container.listen(routerProvider, (_, _) {});
+    addTearDown(subscription.close);
+    final notifier = container.read(routerProvider.notifier);
+    await container.read(routerProvider.future);
+
+    var notificationCount = 0;
+    notifier.addListener(() => notificationCount++);
+
+    authStatus.add(
+      AuthStatus(
+        userId: UserId('signed-in-user'),
+        isAnonymous: false,
+        linkedGoogle: true,
+        linkedApple: false,
+      ),
+    );
+    await pumpEventQueue();
+
+    expect(notificationCount, greaterThan(0));
+  });
+}

--- a/firebase.json
+++ b/firebase.json
@@ -59,6 +59,15 @@
   "storage": {
     "rules": "storage.rules"
   },
+  "auth": {
+    "providers": {
+      "anonymous": true,
+      "googleSignIn": {
+        "oAuthBrandDisplayName": "これほしい！",
+        "supportEmail": "yakitamagmo@gmail.com"
+      }
+    }
+  },
   "remoteconfig": {
     "template": "remoteconfig.template.json"
   }

--- a/functions/index.js
+++ b/functions/index.js
@@ -297,6 +297,7 @@ exports.v2OnCreateMessage = onDocumentCreated(
               body: messageData.body,
             },
             data: {
+              groupId: event.params.groupId,
               path: messageData.path,
             },
             android: {

--- a/functions/test/firebase.rules.test.js
+++ b/functions/test/firebase.rules.test.js
@@ -18,7 +18,7 @@ const {
   uploadString,
 } = require('firebase/storage');
 
-const projectId = 'demo-korehosi';
+const projectId = process.env.GCLOUD_PROJECT || 'demo-korehosi';
 const groupId = 'family';
 const memberId = 'member';
 const outsiderId = 'outsider';

--- a/packages/application/lib/item.dart
+++ b/packages/application/lib/item.dart
@@ -10,6 +10,7 @@ export 'src/item/state/item_detail_providers.dart';
 export 'src/item/state/item_provider.dart';
 export 'src/item/state/items_search_query_notifier_provider.dart';
 export 'src/item/state/items_view_layout_notifier_provider.dart';
+export 'src/item/state/search_all_items_provider.dart';
 export 'src/item/state/search_items_provider.dart';
 export 'src/item/state/wanter_name_suggestion_provider.dart';
 export 'src/item/usecase/item_usecase.dart';

--- a/packages/application/lib/src/item/state/search_all_items_provider.dart
+++ b/packages/application/lib/src/item/state/search_all_items_provider.dart
@@ -1,0 +1,23 @@
+import 'package:packages_application/src/group/state/current_group_id_provider.dart';
+import 'package:packages_application/src/item/state/items_search_query_notifier_provider.dart';
+import 'package:packages_application/src/item/usecase/item_usecase.dart';
+import 'package:packages_application/user.dart';
+import 'package:packages_domain/item.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'search_all_items_provider.g.dart';
+
+/// 詳細画面間の移動に利用する、現在の検索結果すべて。
+@riverpod
+Future<List<Item>> searchAllItems(Ref ref) async {
+  final query = ref.watch(itemsSearchQueryProvider);
+  final groupId = await ref.watch(currentGroupIdProvider.future);
+  final user = await ref.watch(authUserProvider.future);
+  if (groupId == null || user == null) {
+    return const [];
+  }
+
+  return ref
+      .read(itemUsecaseProvider)
+      .searchAllItems(groupId: groupId, ageGroup: user.ageGroup, query: query);
+}

--- a/packages/application/lib/src/item/state/search_all_items_provider.g.dart
+++ b/packages/application/lib/src/item/state/search_all_items_provider.g.dart
@@ -1,0 +1,54 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, duplicate_ignore
+
+part of 'search_all_items_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// 詳細画面間の移動に利用する、現在の検索結果すべて。
+
+@ProviderFor(searchAllItems)
+const searchAllItemsProvider = SearchAllItemsProvider._();
+
+/// 詳細画面間の移動に利用する、現在の検索結果すべて。
+
+final class SearchAllItemsProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<Item>>,
+          List<Item>,
+          FutureOr<List<Item>>
+        >
+    with $FutureModifier<List<Item>>, $FutureProvider<List<Item>> {
+  /// 詳細画面間の移動に利用する、現在の検索結果すべて。
+  const SearchAllItemsProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'searchAllItemsProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$searchAllItemsHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<List<Item>> $createElement($ProviderPointer pointer) =>
+      $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<List<Item>> create(Ref ref) {
+    return searchAllItems(ref);
+  }
+}
+
+String _$searchAllItemsHash() => r'84b2919ef75012a2b7db4d494d84ab680ab4773c';

--- a/packages/application/lib/src/item/usecase/item_usecase.dart
+++ b/packages/application/lib/src/item/usecase/item_usecase.dart
@@ -44,10 +44,47 @@ class ItemUsecase with RunUsecaseMixin {
         );
   }
 
+  /// 現在の検索条件に一致する、すべての欲しいものをページ順に取得する。
+  Future<List<Item>> searchAllItems({
+    required GroupId groupId,
+    required AgeGroup ageGroup,
+    required ItemsSearchQuery query,
+  }) async {
+    final firstPage = await searchItems(
+      page: 1,
+      groupId: groupId,
+      ageGroup: ageGroup,
+      query: query,
+    );
+    final pageCount = (firstPage.totalCount / itemsPageConfig.pageSize).ceil();
+    if (pageCount <= 1) {
+      return firstPage.items;
+    }
+
+    final remainingPages = await Future.wait(
+      [
+        for (var page = 2; page <= pageCount; page++)
+          searchItems(
+            page: page,
+            groupId: groupId,
+            ageGroup: ageGroup,
+            query: query,
+          ),
+      ],
+    );
+
+    return [
+      ...firstPage.items,
+      ...remainingPages.expand((page) => page.items),
+    ];
+  }
+
   /// ほしいもの一覧を再読み込みする.
   Future<void> refreshSearchItems() async {
     // すべての要素を再読み込み
-    ref.invalidate(searchItemsProvider);
+    ref
+      ..invalidate(searchItemsProvider)
+      ..invalidate(searchAllItemsProvider);
 
     // 最初のページ文のデータが取得できるまでは待機
     return ref.read(searchItemsProvider(page: 1).future);
@@ -123,7 +160,8 @@ class ItemUsecase with RunUsecaseMixin {
       // Providerへの反映
       ref
         ..invalidate(itemProvider)
-        ..invalidate(searchItemsProvider);
+        ..invalidate(searchItemsProvider)
+        ..invalidate(searchAllItemsProvider);
 
       // 通知処理
       final itemDetailPath = generateItemDetailRoute(item.id);
@@ -324,6 +362,7 @@ class ItemUsecase with RunUsecaseMixin {
     // Providerへの反映
     ref
       ..invalidate(itemProvider)
-      ..invalidate(searchItemsProvider);
+      ..invalidate(searchItemsProvider)
+      ..invalidate(searchAllItemsProvider);
   }
 }

--- a/packages/application/test/item/usecase/item_usecase_test.dart
+++ b/packages/application/test/item/usecase/item_usecase_test.dart
@@ -96,6 +96,45 @@ void main() {
 
     expect(repository.deletedItemId, isNull);
   });
+
+  test('searchAllItems combines every page in order', () async {
+    final repository = _FakeItemRepository(
+      searchResults: {
+        1: PageInfo(
+          items: List.generate(10, _searchItem),
+          totalCount: 12,
+        ),
+        2: PageInfo(
+          items: List.generate(2, (index) => _searchItem(index + 10)),
+          totalCount: 12,
+        ),
+      },
+    );
+    final container = _container(
+      sourceGroup: sourceGroup,
+      repository: repository,
+    );
+    addTearDown(container.dispose);
+
+    final result = await container
+        .read(itemUsecaseProvider)
+        .searchAllItems(
+          groupId: sourceGroup.id,
+          ageGroup: AgeGroup.adult,
+          query: const ItemsSearchQuery(
+            purchaseStatuses: [],
+            itemsOrder: ItemsOrder(
+              key: ItemOrderKey.createdAt,
+              sortOrder: SortOrder.desc,
+            ),
+          ),
+        );
+
+    expect(repository.searchedPages, [1, 2]);
+    expect(result.map((item) => item.id.value), [
+      for (var index = 0; index < 12; index++) 'item-$index',
+    ]);
+  });
 }
 
 ProviderContainer _container({
@@ -135,10 +174,15 @@ class _FakeStorageService implements StorageService {
 }
 
 class _FakeItemRepository implements ItemRepository {
-  _FakeItemRepository({this.events, this.failToAdd = false});
+  _FakeItemRepository({
+    this.events,
+    this.failToAdd = false,
+    this.searchResults = const {},
+  });
 
   final List<String>? events;
   final bool failToAdd;
+  final Map<int, PageInfo<Item>> searchResults;
 
   GroupId? addedGroupId;
   List<XFile>? uploadImages;
@@ -152,6 +196,7 @@ class _FakeItemRepository implements ItemRepository {
   String? memo;
   GroupId? deletedGroupId;
   ItemId? deletedItemId;
+  final searchedPages = <int>[];
 
   @override
   Future<Item> add({
@@ -212,7 +257,10 @@ class _FakeItemRepository implements ItemRepository {
     required GroupId groupId,
     required AgeGroup ageGroup,
     required ItemsSearchQuery query,
-  }) async => const PageInfo(items: [], totalCount: 0);
+  }) async {
+    searchedPages.add(page);
+    return searchResults[page] ?? const PageInfo(items: [], totalCount: 0);
+  }
 
   @override
   Future<void> update({
@@ -234,6 +282,15 @@ class _FakeItemRepository implements ItemRepository {
 final _item = Item(
   id: ItemId('copied'),
   name: 'copied',
+  wishRank: 1,
+  purchaseStatus: PurchaseStatus.notPurchased,
+  createdAt: DateTime(2026),
+  updatedAt: DateTime(2026),
+);
+
+Item _searchItem(int index) => Item(
+  id: ItemId('item-$index'),
+  name: 'item-$index',
   wishRank: 1,
   purchaseStatus: PurchaseStatus.notPurchased,
   createdAt: DateTime(2026),

--- a/packages/designsystem/lib/src/components/components.dart
+++ b/packages/designsystem/lib/src/components/components.dart
@@ -19,6 +19,8 @@ export 'src/edit_icon_button.dart';
 export 'src/edit_icon_container.dart';
 export 'src/error_view.dart';
 export 'src/expand_width_container.dart';
+export 'src/expressive_loading_indicator.dart';
+export 'src/expressive_refresh_indicator.dart';
 export 'src/gauge_chart.dart';
 export 'src/google_icon.dart';
 export 'src/image_aspect_ratio.dart';

--- a/packages/designsystem/lib/src/components/src/expressive_loading_indicator.dart
+++ b/packages/designsystem/lib/src/components/src/expressive_loading_indicator.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:material3_indicators/material3_indicators.dart';
+
+/// Material 3 Expressive の形状モーフィングローダー。
+class ExpressiveLoadingIndicator extends StatelessWidget {
+  const ExpressiveLoadingIndicator({
+    super.key,
+    this.size = 36,
+    this.contained = false,
+    this.containerSize = 48,
+    this.semanticsLabel,
+  });
+
+  final double size;
+  final bool contained;
+  final double containerSize;
+  final String? semanticsLabel;
+
+  @override
+  Widget build(BuildContext context) => M3LoadingIndicator(
+    size: size,
+    contained: contained,
+    containerSize: containerSize,
+    semanticsLabel: semanticsLabel,
+  );
+}

--- a/packages/designsystem/lib/src/components/src/expressive_refresh_indicator.dart
+++ b/packages/designsystem/lib/src/components/src/expressive_refresh_indicator.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+
+import 'expressive_loading_indicator.dart';
+
+/// Pull-to-refresh を Material 3 Expressive のローダーで表示する。
+class ExpressiveRefreshIndicator extends StatefulWidget {
+  const ExpressiveRefreshIndicator({
+    super.key,
+    required this.onRefresh,
+    required this.child,
+    this.displacement = 40,
+    this.notificationPredicate = defaultScrollNotificationPredicate,
+    this.triggerMode = RefreshIndicatorTriggerMode.onEdge,
+  });
+
+  final RefreshCallback onRefresh;
+  final Widget child;
+  final double displacement;
+  final ScrollNotificationPredicate notificationPredicate;
+  final RefreshIndicatorTriggerMode triggerMode;
+
+  @override
+  State<ExpressiveRefreshIndicator> createState() =>
+      _ExpressiveRefreshIndicatorState();
+}
+
+class _ExpressiveRefreshIndicatorState
+    extends State<ExpressiveRefreshIndicator> {
+  RefreshIndicatorStatus? _status;
+
+  bool get _showIndicator => switch (_status) {
+    RefreshIndicatorStatus.drag ||
+    RefreshIndicatorStatus.armed ||
+    RefreshIndicatorStatus.snap ||
+    RefreshIndicatorStatus.refresh => true,
+    _ => false,
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        RefreshIndicator.noSpinner(
+          onRefresh: widget.onRefresh,
+          onStatusChange: (status) => setState(() => _status = status),
+          notificationPredicate: widget.notificationPredicate,
+          triggerMode: widget.triggerMode,
+          child: widget.child,
+        ),
+        if (_showIndicator)
+          Positioned(
+            top: widget.displacement,
+            left: 0,
+            right: 0,
+            child: IgnorePointer(
+              child: ExpressiveLoadingIndicator(
+                contained: true,
+                size: 24,
+                semanticsLabel: MaterialLocalizations.of(
+                  context,
+                ).refreshIndicatorSemanticLabel,
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/packages/designsystem/lib/src/components/src/image_crop_page.dart
+++ b/packages/designsystem/lib/src/components/src/image_crop_page.dart
@@ -4,6 +4,8 @@ import 'package:crop_your_image/crop_your_image.dart';
 import 'package:flutter/material.dart';
 import 'package:packages_designsystem/i18n.dart';
 
+import 'expressive_loading_indicator.dart';
+
 class ImageCropPage extends StatefulWidget {
   const ImageCropPage({super.key, required this.image});
 
@@ -50,7 +52,7 @@ class _ImageCropPageState extends State<ImageCropPage> {
             const Positioned.fill(
               child: ColoredBox(
                 color: Color(0x66000000),
-                child: Center(child: CircularProgressIndicator()),
+                child: Center(child: ExpressiveLoadingIndicator()),
               ),
             ),
         ],

--- a/packages/designsystem/lib/src/components/src/loader_overlay.dart
+++ b/packages/designsystem/lib/src/components/src/loader_overlay.dart
@@ -3,6 +3,8 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:nested/nested.dart';
 import 'package:packages_application/common.dart';
 
+import 'expressive_loading_indicator.dart';
+
 class LoaderOverlay extends SingleChildStatelessWidget {
   const LoaderOverlay({super.key, super.child});
 
@@ -20,7 +22,7 @@ class LoaderOverlay extends SingleChildStatelessWidget {
 
             return const ColoredBox(
               color: Colors.black54,
-              child: Center(child: CircularProgressIndicator.adaptive()),
+              child: Center(child: ExpressiveLoadingIndicator()),
             );
           },
         ),

--- a/packages/designsystem/pubspec.yaml
+++ b/packages/designsystem/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
   intl: ^0.20.2
   linked_scroll_controller: ^0.2.0
   lottie: ^3.3.2
+  material3_indicators: ^2026.7.12+2
   material_color_utilities: ^0.13.0
   nested: ^1.0.0
   packages_application:

--- a/packages/designsystem/test/components/expressive_indicators_test.dart
+++ b/packages/designsystem/test/components/expressive_indicators_test.dart
@@ -1,0 +1,63 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material3_indicators/material3_indicators.dart';
+import 'package:packages_designsystem/widgets.dart';
+
+void main() {
+  testWidgets('uses the Material 3 expressive loading indicator', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: ExpressiveLoadingIndicator()),
+    );
+
+    expect(find.byType(M3LoadingIndicator), findsOneWidget);
+  });
+
+  testWidgets('shows the expressive indicator while refreshing', (
+    tester,
+  ) async {
+    final refresh = Completer<void>();
+    var refreshStarted = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ExpressiveRefreshIndicator(
+            onRefresh: () {
+              refreshStarted = true;
+              return refresh.future;
+            },
+            child: ListView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              children: const [SizedBox(height: 400)],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byType(ListView)),
+    );
+    await gesture.moveBy(const Offset(0, 150));
+    await tester.pump();
+    await gesture.moveBy(const Offset(0, 250));
+    await tester.pump();
+
+    expect(find.byType(M3LoadingIndicator), findsOneWidget);
+
+    await gesture.up();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    expect(refreshStarted, isTrue);
+
+    refresh.complete();
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(find.byType(M3LoadingIndicator), findsNothing);
+  });
+}

--- a/packages/domain/lib/src/notification/entity/notification_message.dart
+++ b/packages/domain/lib/src/notification/entity/notification_message.dart
@@ -1,4 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:packages_domain/group.dart';
 
 part 'notification_message.freezed.dart';
 
@@ -11,6 +12,7 @@ abstract class NotificationMessage with _$NotificationMessage {
   const factory NotificationMessage({
     NotificationMessageSenderId? senderId,
     String? category,
+    GroupId? groupId,
     required String? path,
     String? from,
     NotificationMessageId? messageId,

--- a/packages/domain/lib/src/notification/entity/notification_message.freezed.dart
+++ b/packages/domain/lib/src/notification/entity/notification_message.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$NotificationMessage {
 
- NotificationMessageSenderId? get senderId; String? get category; String? get path; String? get from; NotificationMessageId? get messageId; String? get messageType;
+ NotificationMessageSenderId? get senderId; String? get category; GroupId? get groupId; String? get path; String? get from; NotificationMessageId? get messageId; String? get messageType;
 /// Create a copy of NotificationMessage
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +25,16 @@ $NotificationMessageCopyWith<NotificationMessage> get copyWith => _$Notification
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is NotificationMessage&&(identical(other.senderId, senderId) || other.senderId == senderId)&&(identical(other.category, category) || other.category == category)&&(identical(other.path, path) || other.path == path)&&(identical(other.from, from) || other.from == from)&&(identical(other.messageId, messageId) || other.messageId == messageId)&&(identical(other.messageType, messageType) || other.messageType == messageType));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is NotificationMessage&&(identical(other.senderId, senderId) || other.senderId == senderId)&&(identical(other.category, category) || other.category == category)&&(identical(other.groupId, groupId) || other.groupId == groupId)&&(identical(other.path, path) || other.path == path)&&(identical(other.from, from) || other.from == from)&&(identical(other.messageId, messageId) || other.messageId == messageId)&&(identical(other.messageType, messageType) || other.messageType == messageType));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,senderId,category,path,from,messageId,messageType);
+int get hashCode => Object.hash(runtimeType,senderId,category,groupId,path,from,messageId,messageType);
 
 @override
 String toString() {
-  return 'NotificationMessage(senderId: $senderId, category: $category, path: $path, from: $from, messageId: $messageId, messageType: $messageType)';
+  return 'NotificationMessage(senderId: $senderId, category: $category, groupId: $groupId, path: $path, from: $from, messageId: $messageId, messageType: $messageType)';
 }
 
 
@@ -45,7 +45,7 @@ abstract mixin class $NotificationMessageCopyWith<$Res>  {
   factory $NotificationMessageCopyWith(NotificationMessage value, $Res Function(NotificationMessage) _then) = _$NotificationMessageCopyWithImpl;
 @useResult
 $Res call({
- NotificationMessageSenderId? senderId, String? category, String? path, String? from, NotificationMessageId? messageId, String? messageType
+ NotificationMessageSenderId? senderId, String? category, GroupId? groupId, String? path, String? from, NotificationMessageId? messageId, String? messageType
 });
 
 
@@ -62,11 +62,12 @@ class _$NotificationMessageCopyWithImpl<$Res>
 
 /// Create a copy of NotificationMessage
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? senderId = freezed,Object? category = freezed,Object? path = freezed,Object? from = freezed,Object? messageId = freezed,Object? messageType = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? senderId = freezed,Object? category = freezed,Object? groupId = freezed,Object? path = freezed,Object? from = freezed,Object? messageId = freezed,Object? messageType = freezed,}) {
   return _then(_self.copyWith(
 senderId: freezed == senderId ? _self.senderId : senderId // ignore: cast_nullable_to_non_nullable
 as NotificationMessageSenderId?,category: freezed == category ? _self.category : category // ignore: cast_nullable_to_non_nullable
-as String?,path: freezed == path ? _self.path : path // ignore: cast_nullable_to_non_nullable
+as String?,groupId: freezed == groupId ? _self.groupId : groupId // ignore: cast_nullable_to_non_nullable
+as GroupId?,path: freezed == path ? _self.path : path // ignore: cast_nullable_to_non_nullable
 as String?,from: freezed == from ? _self.from : from // ignore: cast_nullable_to_non_nullable
 as String?,messageId: freezed == messageId ? _self.messageId : messageId // ignore: cast_nullable_to_non_nullable
 as NotificationMessageId?,messageType: freezed == messageType ? _self.messageType : messageType // ignore: cast_nullable_to_non_nullable
@@ -155,10 +156,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( NotificationMessageSenderId? senderId,  String? category,  String? path,  String? from,  NotificationMessageId? messageId,  String? messageType)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( NotificationMessageSenderId? senderId,  String? category,  GroupId? groupId,  String? path,  String? from,  NotificationMessageId? messageId,  String? messageType)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _NotificationMessage() when $default != null:
-return $default(_that.senderId,_that.category,_that.path,_that.from,_that.messageId,_that.messageType);case _:
+return $default(_that.senderId,_that.category,_that.groupId,_that.path,_that.from,_that.messageId,_that.messageType);case _:
   return orElse();
 
 }
@@ -176,10 +177,10 @@ return $default(_that.senderId,_that.category,_that.path,_that.from,_that.messag
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( NotificationMessageSenderId? senderId,  String? category,  String? path,  String? from,  NotificationMessageId? messageId,  String? messageType)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( NotificationMessageSenderId? senderId,  String? category,  GroupId? groupId,  String? path,  String? from,  NotificationMessageId? messageId,  String? messageType)  $default,) {final _that = this;
 switch (_that) {
 case _NotificationMessage():
-return $default(_that.senderId,_that.category,_that.path,_that.from,_that.messageId,_that.messageType);case _:
+return $default(_that.senderId,_that.category,_that.groupId,_that.path,_that.from,_that.messageId,_that.messageType);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -196,10 +197,10 @@ return $default(_that.senderId,_that.category,_that.path,_that.from,_that.messag
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( NotificationMessageSenderId? senderId,  String? category,  String? path,  String? from,  NotificationMessageId? messageId,  String? messageType)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( NotificationMessageSenderId? senderId,  String? category,  GroupId? groupId,  String? path,  String? from,  NotificationMessageId? messageId,  String? messageType)?  $default,) {final _that = this;
 switch (_that) {
 case _NotificationMessage() when $default != null:
-return $default(_that.senderId,_that.category,_that.path,_that.from,_that.messageId,_that.messageType);case _:
+return $default(_that.senderId,_that.category,_that.groupId,_that.path,_that.from,_that.messageId,_that.messageType);case _:
   return null;
 
 }
@@ -211,11 +212,12 @@ return $default(_that.senderId,_that.category,_that.path,_that.from,_that.messag
 
 
 class _NotificationMessage implements NotificationMessage {
-  const _NotificationMessage({this.senderId, this.category, required this.path, this.from, this.messageId, this.messageType});
+  const _NotificationMessage({this.senderId, this.category, this.groupId, required this.path, this.from, this.messageId, this.messageType});
   
 
 @override final  NotificationMessageSenderId? senderId;
 @override final  String? category;
+@override final  GroupId? groupId;
 @override final  String? path;
 @override final  String? from;
 @override final  NotificationMessageId? messageId;
@@ -231,16 +233,16 @@ _$NotificationMessageCopyWith<_NotificationMessage> get copyWith => __$Notificat
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _NotificationMessage&&(identical(other.senderId, senderId) || other.senderId == senderId)&&(identical(other.category, category) || other.category == category)&&(identical(other.path, path) || other.path == path)&&(identical(other.from, from) || other.from == from)&&(identical(other.messageId, messageId) || other.messageId == messageId)&&(identical(other.messageType, messageType) || other.messageType == messageType));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _NotificationMessage&&(identical(other.senderId, senderId) || other.senderId == senderId)&&(identical(other.category, category) || other.category == category)&&(identical(other.groupId, groupId) || other.groupId == groupId)&&(identical(other.path, path) || other.path == path)&&(identical(other.from, from) || other.from == from)&&(identical(other.messageId, messageId) || other.messageId == messageId)&&(identical(other.messageType, messageType) || other.messageType == messageType));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,senderId,category,path,from,messageId,messageType);
+int get hashCode => Object.hash(runtimeType,senderId,category,groupId,path,from,messageId,messageType);
 
 @override
 String toString() {
-  return 'NotificationMessage(senderId: $senderId, category: $category, path: $path, from: $from, messageId: $messageId, messageType: $messageType)';
+  return 'NotificationMessage(senderId: $senderId, category: $category, groupId: $groupId, path: $path, from: $from, messageId: $messageId, messageType: $messageType)';
 }
 
 
@@ -251,7 +253,7 @@ abstract mixin class _$NotificationMessageCopyWith<$Res> implements $Notificatio
   factory _$NotificationMessageCopyWith(_NotificationMessage value, $Res Function(_NotificationMessage) _then) = __$NotificationMessageCopyWithImpl;
 @override @useResult
 $Res call({
- NotificationMessageSenderId? senderId, String? category, String? path, String? from, NotificationMessageId? messageId, String? messageType
+ NotificationMessageSenderId? senderId, String? category, GroupId? groupId, String? path, String? from, NotificationMessageId? messageId, String? messageType
 });
 
 
@@ -268,11 +270,12 @@ class __$NotificationMessageCopyWithImpl<$Res>
 
 /// Create a copy of NotificationMessage
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? senderId = freezed,Object? category = freezed,Object? path = freezed,Object? from = freezed,Object? messageId = freezed,Object? messageType = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? senderId = freezed,Object? category = freezed,Object? groupId = freezed,Object? path = freezed,Object? from = freezed,Object? messageId = freezed,Object? messageType = freezed,}) {
   return _then(_NotificationMessage(
 senderId: freezed == senderId ? _self.senderId : senderId // ignore: cast_nullable_to_non_nullable
 as NotificationMessageSenderId?,category: freezed == category ? _self.category : category // ignore: cast_nullable_to_non_nullable
-as String?,path: freezed == path ? _self.path : path // ignore: cast_nullable_to_non_nullable
+as String?,groupId: freezed == groupId ? _self.groupId : groupId // ignore: cast_nullable_to_non_nullable
+as GroupId?,path: freezed == path ? _self.path : path // ignore: cast_nullable_to_non_nullable
 as String?,from: freezed == from ? _self.from : from // ignore: cast_nullable_to_non_nullable
 as String?,messageId: freezed == messageId ? _self.messageId : messageId // ignore: cast_nullable_to_non_nullable
 as NotificationMessageId?,messageType: freezed == messageType ? _self.messageType : messageType // ignore: cast_nullable_to_non_nullable

--- a/packages/infrastructure/firebase/lib/src/common/extension/remote_message_extension.dart
+++ b/packages/infrastructure/firebase/lib/src/common/extension/remote_message_extension.dart
@@ -1,4 +1,5 @@
 import 'package:fcm_config/fcm_config.dart';
+import 'package:packages_domain/group.dart';
 import 'package:packages_domain/notification.dart';
 
 extension RemoteMessageX on RemoteMessage {
@@ -6,6 +7,10 @@ extension RemoteMessageX on RemoteMessage {
   NotificationMessage toDomainModel() => NotificationMessage(
     senderId: senderId == null ? null : NotificationMessageSenderId(senderId!),
     category: category,
+    groupId: switch (data['groupId']) {
+      final String value when value.isNotEmpty => GroupId(value),
+      _ => null,
+    },
     path: data['path'] as String?,
     from: from,
     messageId: messageId == null ? null : NotificationMessageId(messageId!),

--- a/packages/infrastructure/firebase/test/src/common/extension/remote_message_extension_test.dart
+++ b/packages/infrastructure/firebase/test/src/common/extension/remote_message_extension_test.dart
@@ -1,0 +1,17 @@
+import 'package:fcm_config/fcm_config.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:infrastructure_firebase/src/common/extension/remote_message_extension.dart';
+
+void main() {
+  test('maps notification routing data', () {
+    final message = const RemoteMessage(
+      data: {
+        'groupId': 'target-group',
+        'path': '/items/item/target-item',
+      },
+    ).toDomainModel();
+
+    expect(message.groupId?.value, 'target-group');
+    expect(message.path, '/items/item/target-item');
+  });
+}

--- a/packages/infrastructure/mock/lib/src/common/service/mock_messaging_service.dart
+++ b/packages/infrastructure/mock/lib/src/common/service/mock_messaging_service.dart
@@ -5,7 +5,10 @@ import 'package:packages_domain/user.dart';
 class MockMessagingService extends MessagingService {
   @override
   Future<NotificationMessage?> getInitialMessage() async {
-    return const NotificationMessage(path: '/items/item/PFe1fICV0PgqlbTWNrMo');
+    return NotificationMessage(
+      groupId: GroupId('mock-group'),
+      path: '/items/item/PFe1fICV0PgqlbTWNrMo',
+    );
   }
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1461,6 +1461,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.12.19"
+  material3_indicators:
+    dependency: transitive
+    description:
+      name: material3_indicators
+      sha256: a18c59abc9c3617300619869275ba3f1dc25b0296c12428796ae85edab69bbb7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2026.7.12+2"
   material_color_utilities:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,6 +54,7 @@ melos:
         hooks_riverpod: ^3.0.3
         intl: ^0.20.2
         json_annotation: ^4.9.0
+        material3_indicators: ^2026.7.12+2
         nested: ^1.0.0
         reactive_forms: ^18.2.0
         responsive_framework: ^1.5.1


### PR DESCRIPTION
## 概要

オープンしている Issue #105〜#111 をすべて対応します。

- 通知元グループへ切り替えてから遷移
- 認証状態変更時のルーター再評価
- 商品詳細の横スワイプ移動
- 一覧のスライド削除
- Material 3 Expressive 進捗表示
- Android 予測型戻るジェスチャー
- Firebase Google Sign-In ブランド名設定

## 検証

- flutter analyze --no-pub
- 全 workspace の flutter test（CI define）
- dart fix --dry-run
- cspell
- Firebase Functions lint
- Firestore / Storage Rules Emulator tests
- iOS Simulator 通常起動
- Patrol iOS smoke test
- Android debug APK build
- Firebase Auth production deploy

Closes #105
Closes #106
Closes #107
Closes #108
Closes #109
Closes #110
Closes #111

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * アイテム詳細を横スワイプで切り替えられるようになりました。
  * アイテム一覧からスワイプして削除でき、確認ダイアログも表示されます。
  * 通知から対象グループを選択して、関連ページへ移動できるようになりました。
  * 通知にグループ情報が含まれるようになりました。

* **改善**
  * ローディングやプルダウン更新の表示を新しいデザインに統一しました。
  * 認証状態の変更が画面遷移へ正しく反映されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->