### PR TITLE
fix(ci): バージョンアップpushがブランチ保護に阻まれる問題を修正

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -32,7 +32,11 @@ jobs:
     outputs:
       release_sha: ${{ steps.publish.outputs.release_sha }}
     steps:
+      # main は保護ブランチのため GITHUB_TOKEN では push できない。
+      # admin 権限を持つ PAT (RELEASE_PAT) を使ってブランチ保護をバイパスする。
       - uses: actions/checkout@v7
+        with:
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Flutter バージョンの取得 (.fvmrc)
         id: fvm

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -32,11 +32,9 @@ jobs:
     outputs:
       release_sha: ${{ steps.publish.outputs.release_sha }}
     steps:
-      # main は保護ブランチのため GITHUB_TOKEN では push できない。
-      # admin 権限を持つ PAT (RELEASE_PAT) を使ってブランチ保護をバイパスする。
       - uses: actions/checkout@v7
         with:
-          token: ${{ secrets.RELEASE_PAT }}
+          persist-credentials: false
 
       - name: Flutter バージョンの取得 (.fvmrc)
         id: fvm
@@ -64,13 +62,17 @@ jobs:
 
       - name: 変更のコミットとタグの作成
         id: publish
+        env:
+          # main は保護ブランチのため GITHUB_TOKEN では push できない。
+          # admin 権限を持つ PAT (RELEASE_PAT) を push 直前のみ使ってブランチ保護をバイパスする。
+          RELEASE_PAT: ${{ secrets.RELEASE_PAT }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add apps/app/pubspec.yaml
           git commit -m "🔖tag: v${{ steps.bump.outputs.new_version }} へバージョンアップ"
           git tag "v${{ steps.bump.outputs.new_version }}"
-          git push --atomic origin \
+          git push --atomic "https://x-access-token:${RELEASE_PAT}@github.com/${GITHUB_REPOSITORY}.git" \
             "HEAD:refs/heads/${{ github.ref_name }}" \
             "refs/tags/v${{ steps.bump.outputs.new_version }}"
           echo "release_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## 関連するIssue
なし

## やったこと
- `main` はブランチ保護（PR必須 / 必須ステータスチェック 2件）が有効なため、`build_and_publish.yml` の `version_up` ジョブが `GITHUB_TOKEN` でバージョンアップコミットを push しようとすると `GH006: Protected branch update failed` で失敗していた
- admin 権限を持つ PAT (`RELEASE_PAT` secret) を、push を行うステップの `env` にのみ渡し、`git push` の URL 認証情報として使うことで branch protection をバイパスするよう修正
- checkout ステップは `persist-credentials: false` とし、PAT が後続の他ステップ（cider install 等）から参照できる状態を残さないようにした

## やらないこと
- `actions/checkout` の commit SHA 固定（CodeRabbit nitpick）は対応しない。他の checkout ステップ（91, 190行目）が `@v7` タグ参照のままのため、1箇所だけ固定すると一貫性が崩れるため今回は見送り

## スクリーンショット
なし（CI設定変更のため）

## テスト計画
- [ ] `workflow_dispatch` で `Build and Publish` を `bump_type=patch` などで実行し、`version_up` ジョブが成功し main へバージョンアップコミット＋タグが push されることを確認
  - 注意: 成功すると `build-ios` / `build-android` ジョブが続けて実行され、実際に App Store Connect / Google Play internal track への配布まで進む