### PR TITLE
fix(profile): 登録後の年齢区分を読み取り専用にする

### DIFF
--- a/apps/app/assets/i18n/user_en.i18n.yaml
+++ b/apps/app/assets/i18n/user_en.i18n.yaml
@@ -1,1 +1,3 @@
+profilePage:
+  ageGroupCannotBeChanged: Age group can't be changed after registration.
 hoge: hoge

--- a/apps/app/assets/i18n/user_ja.i18n.yaml
+++ b/apps/app/assets/i18n/user_ja.i18n.yaml
@@ -4,6 +4,7 @@ welcomePage:
   accountLink: アカウント連携
 profilePage:
   profile: プロフィール
+  ageGroupCannotBeChanged: 年齢層は登録後に変更できません
 onboardPage:
   start: はじめる
   introduction: 

--- a/apps/app/lib/app/pages/user/components/age_group_field.dart
+++ b/apps/app/lib/app/pages/user/components/age_group_field.dart
@@ -5,15 +5,24 @@ import 'package:packages_application/user.dart';
 import 'package:packages_designsystem/widgets.dart';
 
 class AgeGroupField extends HookWidget {
-  const AgeGroupField({super.key, this.fieldKey});
+  const AgeGroupField({
+    super.key,
+    this.fieldKey,
+    this.helperText,
+    this.readOnly = false,
+  });
 
   final Key? fieldKey;
+  final String? helperText;
+  final bool readOnly;
 
   @override
   Widget build(BuildContext context) {
     return ReactiveSegmentedButton(
       formControlName: UserFormModelForm.ageGroupControlName,
       labelText: i18n.user.common.ageGroup,
+      helperText: helperText,
+      readOnly: readOnly,
     );
   }
 }

--- a/apps/app/lib/app/pages/user/profile_page.dart
+++ b/apps/app/lib/app/pages/user/profile_page.dart
@@ -49,11 +49,18 @@ class _Form extends HookWidget {
           title: Text(i18n.user.profilePage.profile),
           actions: const [_SaveButton()],
         ),
-        body: const SingleChildScrollView(
+        body: SingleChildScrollView(
           child: PagePadding(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
-              children: [UserNameField(), Gap(16), AgeGroupField()],
+              children: [
+                const UserNameField(),
+                const Gap(16),
+                AgeGroupField(
+                  readOnly: true,
+                  helperText: i18n.user.profilePage.ageGroupCannotBeChanged,
+                ),
+              ],
             ),
           ),
         ),
@@ -82,14 +89,11 @@ class _SaveButton extends HookConsumerWidget with PresentationMixin {
         // 画面の入力内容を取得
         final formModel = ReactiveUserFormModelForm.of(context)!;
         final name = formModel.nameControl.value;
-        final ageGroup = formModel.ageGroupControl.value;
 
         final navigator = Navigator.of(context);
 
         // 登録
-        await ref
-            .read(userUsecaseProvider)
-            .update(name: name, ageGroup: ageGroup!);
+        await ref.read(userUsecaseProvider).update(name: name);
 
         // 遷移元へ
         navigator.pop();

--- a/apps/app/lib/i18n/strings.g.dart
+++ b/apps/app/lib/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 176 (88 per locale)
+/// Strings: 178 (89 per locale)
 ///
-/// Built on 2026-07-23 at 02:10 UTC
+/// Built on 2026-08-10 at 16:10 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/apps/app/lib/i18n/strings_en.g.dart
+++ b/apps/app/lib/i18n/strings_en.g.dart
@@ -101,6 +101,7 @@ class _TranslationsUserEn extends TranslationsUserJa {
 	final TranslationsEn _root; // ignore: unused_field
 
 	// Translations
+	@override late final _TranslationsUserProfilePageEn profilePage = _TranslationsUserProfilePageEn._(_root);
 	@override String get hoge => 'hoge';
 }
 
@@ -142,6 +143,16 @@ class _TranslationsSettingsAccountPageEn extends TranslationsSettingsAccountPage
 	@override late final _TranslationsSettingsAccountPageLinkEn link = _TranslationsSettingsAccountPageLinkEn._(_root);
 	@override late final _TranslationsSettingsAccountPageOtherEn other = _TranslationsSettingsAccountPageOtherEn._(_root);
 	@override late final _TranslationsSettingsAccountPageLeaveConfirmDialogEn leaveConfirmDialog = _TranslationsSettingsAccountPageLeaveConfirmDialogEn._(_root);
+}
+
+// Path: user.profilePage
+class _TranslationsUserProfilePageEn extends TranslationsUserProfilePageJa {
+	_TranslationsUserProfilePageEn._(TranslationsEn root) : this._root = root, super.internal(root);
+
+	final TranslationsEn _root; // ignore: unused_field
+
+	// Translations
+	@override String get ageGroupCannotBeChanged => 'Age group can\'t be changed after registration.';
 }
 
 // Path: settings.settingsPage.account
@@ -322,6 +333,7 @@ extension on TranslationsEn {
 			'settings.accountPage.other.leave' => 'Leave',
 			'settings.accountPage.leaveConfirmDialog.title' => 'Leave?',
 			'settings.accountPage.leaveConfirmDialog.body' => 'Are you sure you want to cancel your membership? \\Ўn this operation cannot be undone.',
+			'user.profilePage.ageGroupCannotBeChanged' => 'Age group can\'t be changed after registration.',
 			'user.hoge' => 'hoge',
 			_ => null,
 		};

--- a/apps/app/lib/i18n/strings_ja.g.dart
+++ b/apps/app/lib/i18n/strings_ja.g.dart
@@ -468,6 +468,9 @@ class TranslationsUserProfilePageJa {
 
 	/// ja: 'プロフィール'
 	String get profile => 'プロフィール';
+
+	/// ja: '年齢層は登録後に変更できません'
+	String get ageGroupCannotBeChanged => '年齢層は登録後に変更できません';
 }
 
 // Path: user.onboardPage
@@ -1084,6 +1087,7 @@ extension on Translations {
 			'user.welcomePage.forFirstTimers' => 'はじめての方はこちら',
 			'user.welcomePage.accountLink' => 'アカウント連携',
 			'user.profilePage.profile' => 'プロフィール',
+			'user.profilePage.ageGroupCannotBeChanged' => '年齢層は登録後に変更できません',
 			'user.onboardPage.start' => 'はじめる',
 			'user.onboardPage.introduction.title' => 'はじめに',
 			'user.onboardPage.introduction.message' => 'まずはプロフィールを登録しましょう',

--- a/apps/app/test/app/presentation/pages/user/profile_age_group_test.dart
+++ b/apps/app/test/app/presentation/pages/user/profile_age_group_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_app/app/pages/user/onboard_page.dart';
+import 'package:flutter_app/app/pages/user/profile_page.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:packages_application/user.dart';
+import 'package:packages_domain/user.dart';
+
+import '../../../../test_utils/src/wrapper.dart';
+
+void main() {
+  testWidgets('profile shows the registered age group as read-only', (
+    tester,
+  ) async {
+    final user = User(
+      id: UserId('user'),
+      ageGroup: AgeGroup.child,
+      name: 'User',
+      createdAt: DateTime(2026),
+      updatedAt: DateTime(2026),
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [authUserProvider.overrideWith((ref) => user)],
+        child: testableWidget(const ProfilePage()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final buttonFinder = find.byType(SegmentedButton<AgeGroup>);
+    var button = tester.widget<SegmentedButton<AgeGroup>>(buttonFinder);
+    expect(button.onSelectionChanged, isNull);
+    expect(button.selected, {AgeGroup.child});
+    expect(find.text('年齢層は登録後に変更できません'), findsOneWidget);
+
+    await tester.tap(
+      find.descendant(of: buttonFinder, matching: find.text('おとな')),
+    );
+    await tester.pump();
+
+    button = tester.widget<SegmentedButton<AgeGroup>>(buttonFinder);
+    expect(button.selected, {AgeGroup.child});
+  });
+
+  testWidgets('onboarding still allows age group selection', (tester) async {
+    await tester.pumpWidget(testableWidget(OnboardPage(initialPage: 1)));
+    await tester.pumpAndSettle();
+
+    final buttonFinder = find.byType(SegmentedButton<AgeGroup>);
+    var button = tester.widget<SegmentedButton<AgeGroup>>(buttonFinder);
+    expect(button.onSelectionChanged, isNotNull);
+
+    await tester.tap(
+      find.descendant(of: buttonFinder, matching: find.text('おとな')),
+    );
+    await tester.pump();
+
+    button = tester.widget<SegmentedButton<AgeGroup>>(buttonFinder);
+    expect(button.selected, {AgeGroup.adult});
+  });
+}

--- a/functions/test/firebase.rules.test.js
+++ b/functions/test/firebase.rules.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 
@@ -124,6 +125,29 @@ describe('Firebase security rules', () => {
     await assertFails(
       updateDoc(ownProfile, {joinGroupIds: [groupId, outsiderId]}),
     );
+  });
+
+  it('allows the profile update payload without changing age group', async () => {
+    const profile = doc(adultFirestore(), 'users', adultId);
+
+    await assertSucceeds(
+      setDoc(profile, {
+        id: adultId,
+        ageGroup: 'adult',
+        name: 'Before',
+        joinGroupIds: [groupId],
+      }),
+    );
+    await assertSucceeds(
+      updateDoc(profile, {
+        name: 'After',
+        updatedAt: serverTimestamp(),
+      }),
+    );
+
+    const updatedProfile = await assertSucceeds(getDoc(profile));
+    assert.equal(updatedProfile.data().name, 'After');
+    assert.equal(updatedProfile.data().ageGroup, 'adult');
   });
 
   it('prevents a child from granting themselves adult access', async () => {

--- a/packages/application/lib/src/user/usecase/user_usecase.dart
+++ b/packages/application/lib/src/user/usecase/user_usecase.dart
@@ -78,10 +78,7 @@ class UserUsecase with RunUsecaseMixin {
   }
 
   /// ユーザー情報の更新
-  Future<void> update({
-    required String? name,
-    required AgeGroup ageGroup,
-  }) async {
+  Future<void> update({required String? name}) async {
     await execute(
       ref,
       action: () async {
@@ -93,7 +90,7 @@ class UserUsecase with RunUsecaseMixin {
         // 更新
         await ref
             .read(userRepositoryProvider)
-            .update(userId: userId!, name: name, ageGroup: ageGroup);
+            .update(userId: userId!, name: name);
       },
     );
   }

--- a/packages/designsystem/lib/src/components/src/reactive_segmented_button.dart
+++ b/packages/designsystem/lib/src/components/src/reactive_segmented_button.dart
@@ -11,19 +11,32 @@ class ReactiveSegmentedButton extends ReactiveFormField<AgeGroup, AgeGroup> {
   ReactiveSegmentedButton({
     super.key,
     String? labelText,
+    String? helperText,
+    bool readOnly = false,
     required String formControlName,
   }) : super(
          formControlName: formControlName,
-         builder: (ReactiveFormFieldState<AgeGroup, AgeGroup> field) =>
-             _Form(field, labelText),
+         builder: (ReactiveFormFieldState<AgeGroup, AgeGroup> field) => _Form(
+           field,
+           labelText,
+           helperText: helperText,
+           readOnly: readOnly,
+         ),
        );
 }
 
 class _Form extends HookWidget {
-  const _Form(this.field, this.labelText);
+  const _Form(
+    this.field,
+    this.labelText, {
+    this.helperText,
+    required this.readOnly,
+  });
 
   final ReactiveFormFieldState<AgeGroup, AgeGroup> field;
   final String? labelText;
+  final String? helperText;
+  final bool readOnly;
 
   @override
   Widget build(BuildContext context) {
@@ -46,9 +59,20 @@ class _Form extends HookWidget {
                 )
                 .toList(),
             selected: field.value == null ? {} : {field.value!},
-            onSelectionChanged: (p0) => field.didChange(p0.first),
+            onSelectionChanged: readOnly
+                ? null
+                : (selection) => field.didChange(selection.first),
           ),
         ),
+        if (helperText != null) ...[
+          const Gap(4),
+          Text(
+            helperText!,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
       ],
     );
   }

--- a/packages/designsystem/test/components/reactive_segmented_button_test.dart
+++ b/packages/designsystem/test/components/reactive_segmented_button_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:packages_designsystem/widgets.dart';
+import 'package:packages_domain/user.dart';
+import 'package:reactive_forms/reactive_forms.dart';
+
+void main() {
+  testWidgets('allows age group selection by default', (tester) async {
+    final form = FormGroup({
+      'ageGroup': FormControl<AgeGroup>(value: AgeGroup.child),
+    });
+
+    await tester.pumpWidget(_subject(form: form));
+
+    final button = tester.widget<SegmentedButton<AgeGroup>>(
+      find.byType(SegmentedButton<AgeGroup>),
+    );
+    expect(button.onSelectionChanged, isNotNull);
+
+    button.onSelectionChanged!({AgeGroup.adult});
+    await tester.pump();
+
+    expect(form.control('ageGroup').value, AgeGroup.adult);
+  });
+
+  testWidgets('shows the age group as read-only with an explanation', (
+    tester,
+  ) async {
+    final form = FormGroup({
+      'ageGroup': FormControl<AgeGroup>(value: AgeGroup.child),
+    });
+
+    await tester.pumpWidget(
+      _subject(
+        form: form,
+        readOnly: true,
+        helperText: 'This cannot be changed after registration.',
+      ),
+    );
+
+    final button = tester.widget<SegmentedButton<AgeGroup>>(
+      find.byType(SegmentedButton<AgeGroup>),
+    );
+    expect(button.onSelectionChanged, isNull);
+    expect(button.selected, {AgeGroup.child});
+    expect(
+      find.text('This cannot be changed after registration.'),
+      findsOneWidget,
+    );
+
+    await tester.tap(
+      find.descendant(
+        of: find.byType(SegmentedButton<AgeGroup>),
+        matching: find.text('おとな'),
+      ),
+    );
+    await tester.pump();
+
+    expect(form.control('ageGroup').value, AgeGroup.child);
+  });
+}
+
+Widget _subject({
+  required FormGroup form,
+  bool readOnly = false,
+  String? helperText,
+}) => MaterialApp(
+  home: Scaffold(
+    body: ReactiveForm(
+      formGroup: form,
+      child: ReactiveSegmentedButton(
+        formControlName: 'ageGroup',
+        readOnly: readOnly,
+        helperText: helperText,
+      ),
+    ),
+  ),
+);

--- a/packages/domain/lib/src/user/interface/user_repository.dart
+++ b/packages/domain/lib/src/user/interface/user_repository.dart
@@ -25,7 +25,6 @@ abstract class UserRepository {
   /// ユーザーモデルの更新
   Future<void> update({
     required UserId userId,
-    required AgeGroup ageGroup,
     String? name,
   });
 

--- a/packages/infrastructure/firebase/lib/src/user/repository/firebase_user_repository.dart
+++ b/packages/infrastructure/firebase/lib/src/user/repository/firebase_user_repository.dart
@@ -1,5 +1,7 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart' as auth;
 import 'package:flutter/foundation.dart';
+import 'package:infrastructure_firebase/src/common/enum/firestore_columns.dart';
 import 'package:infrastructure_firebase/src/common/extension/firebase_auth_user_extension.dart';
 import 'package:infrastructure_firebase/src/common/state/firebase_auth_provider.dart';
 import 'package:infrastructure_firebase/src/common/state/firebase_functions_provider.dart';
@@ -90,24 +92,23 @@ class FirebaseUserRepository implements UserRepository {
   @override
   Future<void> update({
     required UserId userId,
-    required AgeGroup ageGroup,
     String? name,
   }) async {
-    // Firestore用のモデルに変換
     final docRef = ref.read(userDocumentRefProvider(userId: userId));
-    final prev = await docRef.get();
-    if (!prev.exists) {
-      throw const BusinessException(BusinessExceptionType.updateTargetNotFound);
+    try {
+      await docRef.update(
+        userProfileUpdateData(
+          name: name,
+          updatedAt: FieldValue.serverTimestamp(),
+        ),
+      );
+    } on FirebaseException catch (error) {
+      final exceptionType = userProfileUpdateBusinessExceptionType(error.code);
+      if (exceptionType != null) {
+        throw BusinessException(exceptionType);
+      }
+      rethrow;
     }
-
-    final param = prev.data()!.copyWith(
-      id: userId.value,
-      ageGroup: ageGroup,
-      name: name,
-    );
-
-    // 更新
-    return ref.read(userDocumentRefProvider(userId: userId)).set(param);
   }
 
   @override
@@ -260,6 +261,23 @@ class FirebaseUserRepository implements UserRepository {
     return _currentUser?.unlink(providerId);
   }
 }
+
+@visibleForTesting
+Map<String, Object?> userProfileUpdateData({
+  required String? name,
+  required Object updatedAt,
+}) => {
+  'name': name,
+  FirestoreColumns.updatedAt.fieldName: updatedAt,
+};
+
+@visibleForTesting
+BusinessExceptionType? userProfileUpdateBusinessExceptionType(
+  String errorCode,
+) => switch (errorCode) {
+  'not-found' => BusinessExceptionType.updateTargetNotFound,
+  _ => null,
+};
 
 BusinessExceptionType? deleteUserBusinessExceptionType(String? errorCode) =>
     switch (errorCode) {

--- a/packages/infrastructure/firebase/test/src/user/repository/firebase_user_repository_test.dart
+++ b/packages/infrastructure/firebase/test/src/user/repository/firebase_user_repository_test.dart
@@ -3,6 +3,30 @@ import 'package:infrastructure_firebase/src/user/repository/firebase_user_reposi
 import 'package:packages_domain/common.dart';
 
 void main() {
+  test('profile updates contain only mutable user fields', () {
+    final updatedAt = Object();
+
+    expect(
+      userProfileUpdateData(name: 'New name', updatedAt: updatedAt),
+      {'name': 'New name', 'updatedAt': same(updatedAt)},
+    );
+    expect(
+      userProfileUpdateData(name: null, updatedAt: updatedAt),
+      {'name': null, 'updatedAt': same(updatedAt)},
+    );
+  });
+
+  test('maps a missing profile update to the existing business error', () {
+    expect(
+      userProfileUpdateBusinessExceptionType('not-found'),
+      BusinessExceptionType.updateTargetNotFound,
+    );
+    expect(
+      userProfileUpdateBusinessExceptionType('permission-denied'),
+      isNull,
+    );
+  });
+
   test('maps delete user errors to business exceptions', () {
     expect(
       deleteUserBusinessExceptionType('not-auth'),


### PR DESCRIPTION
## 概要

プロフィール編集画面で年齢区分を変更できる一方、Firestore Rules は登録後の年齢区分変更を禁止していたため、年齢区分を操作するとプロフィール保存が失敗していました。

プロフィールでは年齢区分を現在値付きの読み取り専用表示にし、更新経路から `ageGroup` を除外します。初回登録（Onboard）の選択操作は従来どおり維持します。

Fixes #129

## 原因

- Profile と Onboard が編集可能な同一コンポーネントを使用していた
- Profile の Usecase / Repository 更新契約が `ageGroup` を受け取っていた
- クライアントの編集可否と、登録後の変更を拒否する Firestore Rules の契約が一致していなかった

## 変更内容

- Profile の年齢区分を読み取り専用に変更
  - 現在値は表示
  - 「登録後に変更できない」旨を日本語・英語で表示
  - 実際に別の区分をタップしても値を変更しない
- `ReactiveSegmentedButton` / `AgeGroupField` に再利用可能な read-only 表示を追加
- Profile 更新APIから `ageGroup` を Usecase / Domain / Infrastructure 全層で除去
- Firestore 更新を全体 `set` ではなく、`name` とサーバー生成 `updatedAt` だけの `update` に限定
  - `name: null`（名前のクリア）は維持
  - 不存在ドキュメントは既存の `updateTargetNotFound` に変換
  - その他の Firebase エラーは握りつぶさず再送出
- Profile / Onboard / 汎用コンポーネント / 更新payload / エラー変換の回帰テストを追加
- Firebase Emulatorで実際のProfile更新payloadが成功し、年齢区分が保持されるRulesテストを追加

## 完了条件

- [x] プロフィール画面で年齢区分の現在値を確認できる
- [x] プロフィール画面で年齢区分を変更できない
- [x] 登録後は変更できない旨を日本語・英語で確認できる
- [x] プロフィール保存時に `ageGroup` を送信しない
- [x] ユーザードキュメント更新は `name` / `updatedAt` 以外を上書きしない
- [x] Onboard では年齢区分を従来どおり選択できる
- [x] Rules の adult→child / child→adult 拒否契約を維持する
- [x] GitHub Actions の Analyze / Test / Firestore Emulator が成功する
- [ ] CodeRabbit の指摘を確認・対応する

## 検証

GitHub Actionsで以下を確認済みです。

- Spell Check: 成功
- Flutter Analyze（custom_lint含む）: 成功
- 全Flutter Test: 成功
- Firebase Test: 成功
  - Functions lint: 成功
  - Functions tests: 56件成功
  - Java 21 / Firestore・Storage EmulatorのRules tests: 成功
  - name / updatedAt 更新成功、ageGroup保持、adult→child拒否、child→adult拒否を確認

ローカルでは、全Flutterテスト（5 packages / 58 tests）と最終追加の例外変換テスト6件、Functions lint/test、差分チェックを実施済みです。

Sol Xhigh の独立レビューは APPROVE（blocker / major なし）です。

## 対象外

調査中に見つかった users 書き込みスキーマのRules厳格化は、責務を分けて #175 で対応します。